### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Supports:
 
 * [BerkeleyDB](http://www.oracle.com/technetwork/database/database-technologies/berkeleydb/downloads/index.html) via [bsddb3](https://www.jcea.es/programacion/pybsddb_doc/).
 * [KyotoCabinet](http://fallabs.com/kyotocabinet/) via [Python 2.x bindings](http://fallabs.com/kyotocabinet/pythonlegacydoc/).
-* [LevelDB](http://leveldb.org/) via [plyvel](https://plyvel.readthedocs.org/en/latest/).
-* [RocksDB](http://rocksdb.org/) via [pyrocksdb](http://pyrocksdb.readthedocs.org/en/v0.4/)
-* [Sqlite4 LSM DB](https://www.sqlite.org/src4/doc/trunk/www/lsmusr.wiki) via [python-lsm-db](http://lsm-db.readthedocs.org/en/latest/)
+* [LevelDB](http://leveldb.org/) via [plyvel](https://plyvel.readthedocs.io/en/latest/).
+* [RocksDB](http://rocksdb.org/) via [pyrocksdb](https://pyrocksdb.readthedocs.io/en/v0.4/)
+* [Sqlite4 LSM DB](https://www.sqlite.org/src4/doc/trunk/www/lsmusr.wiki) via [python-lsm-db](https://lsm-db.readthedocs.io/en/latest/)
 
 Right now KyotoCabinet is the most well-supported database, but the SQLite4 LSM is also pretty robust. The other databases implement the minimal slicing APIs to enable the Model/Secondary Indexing APIs to work.
 

--- a/kvkit/backends/rocks.py
+++ b/kvkit/backends/rocks.py
@@ -2,7 +2,7 @@
 from contextlib import contextmanager
 import struct
 
-# See http://pyrocksdb.readthedocs.org/en/latest/tutorial/index.html
+# See https://pyrocksdb.readthedocs.io/en/latest/tutorial/index.html
 import rocksdb
 
 from kvkit.backends.helpers import clean_key_slice


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.